### PR TITLE
Fix issue #12

### DIFF
--- a/helmstack.py
+++ b/helmstack.py
@@ -261,7 +261,8 @@ def to_file(value):
     if isinstance(value, str):
         fp.write(bytes(value, encoding='utf8'))
     else:
-        fp.write(bytes(yaml.dump(value), encoding='utf8'))
+        dump = yaml.round_trip_dump(value, None, default_style='"')
+        fp.write(bytes(dump, encoding='utf8'))
     return fp.name
 
 


### PR DESCRIPTION
Helm exists with the following error:
Error: failed to parse /tmp/tmp5anwjaas: error converting YAML to JSON: yaml: line 1: found unexpected ':'

When dealing with the following json:
config-maps:
  virk-at: {AT_BASE_URL: https://vivi.at.dk/AtisServicelagMitVirkFrontend/mitVirk.svc/GetMitVirkInfoCvr}

The solution is to ensure all values are quoted